### PR TITLE
update user schema tests to comply with optional fields

### DIFF
--- a/tests/test_schemas/test_user_schemas.py
+++ b/tests/test_schemas/test_user_schemas.py
@@ -7,20 +7,20 @@ from app.schemas.user_schemas import UserBase, UserCreate, UserUpdate, UserRespo
 # Tests for UserBase
 def test_user_base_valid(user_base_data):
     user = UserBase(**user_base_data)
-    assert user.nickname == user_base_data["nickname"]
+    assert user.nickname == user_base_data.get("nickname")
     assert user.email == user_base_data["email"]
 
 # Tests for UserCreate
 def test_user_create_valid(user_create_data):
     user = UserCreate(**user_create_data)
-    assert user.nickname == user_create_data["nickname"]
+    assert user.nickname == user_create_data.get("nickname")
     assert user.password == user_create_data["password"]
 
 # Tests for UserUpdate
 def test_user_update_valid(user_update_data):
     user_update = UserUpdate(**user_update_data)
     assert user_update.email == user_update_data["email"]
-    assert user_update.first_name == user_update_data["first_name"]
+    assert user_update.first_name == user_update_data.get("first_name")
 
 # Tests for UserResponse
 def test_user_response_valid(user_response_data):


### PR DESCRIPTION
The tests for UserBase, UserUpdate, and UserCreate throw KeyErrors because the nickname field is optional on the UserBase model and the first_name field is optional on the UserUpdate pydantic model. 

This means that the user does not need to include these fields in these instances and the tests will be attempting to get the value for a field that may not exist. 

Through using the get method, the test allows for this optional field and will get the default None value if nothing is provided for that field.

Closes #1 